### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
 SystemStatus	KEYWORD1
 
 
-getVCC  KEYWORD2
-getVBatt KEYWORD2
-getFreeRAM KEYWORD2
-getkHz KEYWORD2
-getMHz KEYWORD2
-getTemperatureInternal KEYWORD2
-SleepWakeOnInterrupt KEYWORD2
+getVCC	KEYWORD2
+getVBatt	KEYWORD2
+getFreeRAM	KEYWORD2
+getkHz	KEYWORD2
+getMHz	KEYWORD2
+getTemperatureInternal	KEYWORD2
+SleepWakeOnInterrupt	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords